### PR TITLE
Version 0.5.1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                fsmark
-version:             0.5.0.0
+version:             0.5.1.0
 github:              "0x00002a/fsmark"
 license:             GPL-3
 author:              "Natasha England-Elbro"

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -16,7 +16,14 @@
 -- along with file-shelf.  If not, see <http://www.gnu.org/licenses/>.
 {-# LANGUAGE OverloadedStrings #-}
 
-module Pretty where
+module Pretty
+    ( PrettyPrintable(..)
+    , printList
+    , printLicense
+    , printPath
+    , printVersionInfo
+    )
+where
 
 import           Data.Text                      ( Text
                                                 , append
@@ -46,7 +53,7 @@ printList :: (PrettyPrintable a) => [a] -> IO ()
 printList = mapM_ display
 
 versionString :: Text
-versionString = "0.5.0"
+versionString = "0.5.1"
 
 printVersionInfo :: IO ()
 printVersionInfo = printf "fsm (version %s)\n" versionString
@@ -74,5 +81,12 @@ printLicense = mapM_ putStrLn licenseStr
 
 
 printPath :: Text -> IO ()
-printPath path = putStrLn $ Sys.escapePath (unpack path) Sys.os
+printPath path = Sys.currentOutputMode >>= printPathWithMode path
+
+printPathWithMode :: Text -> Sys.OutputMode -> IO ()
+printPathWithMode path Sys.PipedOutput = putStrLn $ unpack path
+printPathWithMode path Sys.TermOutput =
+    putStrLn $ Sys.escapePath (unpack path) Sys.os
+
+
 

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -81,12 +81,6 @@ printLicense = mapM_ putStrLn licenseStr
 
 
 printPath :: Text -> IO ()
-printPath path = Sys.currentOutputMode >>= printPathWithMode path
-
-printPathWithMode :: Text -> Sys.OutputMode -> IO ()
-printPathWithMode path Sys.PipedOutput = putStrLn $ unpack path
-printPathWithMode path Sys.TermOutput =
-    putStrLn $ Sys.escapePath (unpack path) Sys.os
-
+printPath path = putStrLn $ unpack path
 
 

--- a/src/Sys.hs
+++ b/src/Sys.hs
@@ -21,17 +21,29 @@ module Sys
     , osFromStr
     , os
     , expandPath
+    , OutputMode(..)
+    , currentOutputMode
     )
 where
 
 import qualified System.Info                   as SI
 import qualified System.Directory              as DIR
+import qualified System.IO                     as SIO
 
 
 data OS = Windows | Unix | Unknown deriving(Eq, Show)
 
+data OutputMode = TermOutput | PipedOutput
+
+currentOutputMode :: IO OutputMode
+currentOutputMode = SIO.hIsTerminalDevice SIO.stdout >>= isTerm
+  where
+    isTerm True  = return TermOutput
+    isTerm False = return PipedOutput
+
 
 escapePath :: FilePath -> OS -> FilePath
+escapePath path Unknown  = "\"" ++ path ++ "\""
 escapePath path platform = concatMap (`escapeSegment` platform) path
 
 
@@ -55,3 +67,5 @@ osFromStr _         = Unknown
 expandPath :: FilePath -> IO FilePath
 expandPath ('~' : fp) = (++ fp) <$> DIR.getHomeDirectory
 expandPath fp         = return fp
+
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -196,7 +196,7 @@ escapePathsTest = TestCase $ winTest >> unixTest >> unknownTest
                            "/home\\ /test"
                            (Sys.escapePath "/home /test" Sys.Unix)
     unknownTest = assertEqual "Unknown system path escaped"
-                              "/home\" \"/test"
+                              "\"/home /test\""
                               (Sys.escapePath "/home /test" Sys.Unknown)
 
 


### PR DESCRIPTION
Removes path escaping

This is a small update to remove automatic path escaping, it caused issues in scripts and getting it to work 100% of the time is not feasible.